### PR TITLE
Decorrelate compiler

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,4 @@
+{
+    "esnext": 6,
+    "loopfunc" : true
+}

--- a/lib/cli/cmd/compile.js
+++ b/lib/cli/cmd/compile.js
@@ -154,7 +154,6 @@
                      checkCompiledGameUpToDate,
                      fetchContent,
                      warnAndCompileGame,
-                     convertGameToJSON,
                      saveCompiledGame],
                     callback);
   };

--- a/lib/cli/cmd/compile.js
+++ b/lib/cli/cmd/compile.js
@@ -44,29 +44,14 @@
   };
 
   var fetchContent = function(data, callback) {
-    var files = [];
-    utils.walkDir(data.sourceDir, {}, function(sourcePath, done) {
-      fs.readFile(sourcePath, function(err, content) {
-        if (err) {
-          return done(err);
-        }
-        
-        files.push({
-          name: sourcePath,
-          contents: content.toString()
-        });
-        done();
-      })
-    },function(err) {
-      /* istanbul ignore if */
+    utils.fetchContent(data.sourceDir, function(err, files) {
       if (err) {
         return callback(err);
-      } else {
-        data.files = files;
-        callback(null, data);
       }
-    })
-  }
+      data.files = files;
+      return callback(null, data);
+    });
+  };
 
   var warnAndCompileGame = function(data, callback) {
     if (data.needsCompilation) {

--- a/lib/cli/cmd/compile.js
+++ b/lib/cli/cmd/compile.js
@@ -9,6 +9,7 @@
 
   var path = require('path');
   var async = require('async');
+  var mkdirp = require('mkdirp');
 
   var compiler = require('../../parsers/compiler');
   var utils = require('../utils');
@@ -42,12 +43,37 @@
     }
   };
 
+  var fetchContent = function(data, callback) {
+    var files = [];
+    utils.walkDir(data.sourceDir, {}, function(sourcePath, done) {
+      fs.readFile(sourcePath, function(err, content) {
+        if (err) {
+          return done(err);
+        }
+        
+        files.push({
+          name: sourcePath,
+          contents: content.toString()
+        });
+        done();
+      })
+    },function(err) {
+      /* istanbul ignore if */
+      if (err) {
+        return callback(err);
+      } else {
+        data.files = files;
+        callback(null, data);
+      }
+    })
+  }
+
   var warnAndCompileGame = function(data, callback) {
     if (data.needsCompilation) {
       if (data.command !== 'compile') {
         console.log('Game file is out of date, recompiling.'.red);
       }
-      compiler.compileGame(data.sourceDir, function(err, game) {
+      compiler.compileGame(data.files, function(err, game) {
         if (err) {
           return callback(err);
         }
@@ -67,7 +93,31 @@
       return callback(null, data);
     }
     var indent = data.indent ? 2 : 0;
-    compiler.saveCompiledGame(
+
+    var _saveCompiledGame = function(game, outPath, indent, callback) {
+      convertGameToJSON(game, indent, function(err, json) {
+        /* istanbul ignore if */
+        if (err) {
+          return callback(err);
+        }
+        var diry = path.dirname(outPath);
+        mkdirp(diry, function(err) {
+          /* istanbul ignore if */
+          if (err) {
+            return callback(err);
+          }
+          fs.writeFile(outPath, json, function(err) {
+            /* istanbul ignore if */
+            if (err) {
+              return callback(err);
+            }
+            callback(null);
+          });
+        });
+      });
+    };
+
+    _saveCompiledGame(
       data.game, data.compiledPath, indent, function(err) {
         if (err) {
           return callback(err);
@@ -77,6 +127,8 @@
       }
     );
   };
+
+  
 
   // ----------------------------------------------------------------------
   // Compile: Checks a project is correct and compiles.
@@ -115,7 +167,9 @@
     };
     async.waterfall([getData, ensureProject,
                      checkCompiledGameUpToDate,
+                     fetchContent,
                      warnAndCompileGame,
+                     convertGameToJSON,
                      saveCompiledGame],
                     callback);
   };

--- a/lib/cli/cmd/make-book.js
+++ b/lib/cli/cmd/make-book.js
@@ -13,14 +13,13 @@
   var async = require('async');
 
   var utils = require('../utils');
-  var compiler = require('../../parsers/compiler');
   var cmdCompile = require('./compile').cmd;
   var gamebook = require('../../search/gamebook');
   var html = require('../../ui/content/html');
   var latex = require('../../ui/content/latex');
 
   var loadGameAndSource = function(data, callback) {
-    compiler.loadCompiledGame(data.compiledPath, function(err, game, json) {
+    utils.loadCompiledGame(data.compiledPath, function(err, game, json) {
       if (err) {
         return callback(err);
       }

--- a/lib/cli/cmd/make-html.js
+++ b/lib/cli/cmd/make-html.js
@@ -14,11 +14,10 @@
   var uglify = require('uglify-js');
 
   var utils = require('../utils');
-  var compiler = require('../../parsers/compiler');
   var cmdCompile = require('./compile').cmd;
 
   var loadGameAndSource = function(data, callback) {
-    compiler.loadCompiledGame(data.compiledPath, function(err, game, json) {
+    utils.loadCompiledGame(data.compiledPath, function(err, game, json) {
       if (err) {
         return callback(err);
       }

--- a/lib/cli/cmd/random-test.js
+++ b/lib/cli/cmd/random-test.js
@@ -15,13 +15,12 @@
   var cmdCompile = require('./compile').cmd;
   var CLUserInterface = require('../../ui/cli').CommandLineUserInterface;
   var RandomTestPrompt = require('../../ui/random_prompt').RandomTestPrompt;
-  var compiler = require('../../parsers/compiler');
 
   var loadGame = function(data, callback) {
     if (data.needsCompilation) {
       return callback(null, data);
     }
-    compiler.loadCompiledGame(data.compiledPath, function(err, game) {
+    utils.loadCompiledGame(data.compiledPath, function(err, game) {
       if (err) {
         return callback(err);
       }

--- a/lib/cli/cmd/run.js
+++ b/lib/cli/cmd/run.js
@@ -13,13 +13,12 @@
   var utils = require('../utils');
   var cmdCompile = require('./compile').cmd;
   var CLUserInterface = require('../../ui/cli').CommandLineUserInterface;
-  var compiler = require('../../parsers/compiler');
 
   var loadGame = function(data, callback) {
     if (data.needsCompilation) {
       return callback(null, data);
     }
-    compiler.loadCompiledGame(data.compiledPath, function(err, game) {
+    utils.loadCompiledGame(data.compiledPath, function(err, game) {
       if (err) {
         return callback(err);
       }

--- a/lib/cli/utils.js
+++ b/lib/cli/utils.js
@@ -247,6 +247,30 @@
     });
   };
 
+  var fetchContent = function(diry, callback) {
+    var files = [];
+    walkDir(diry, {}, function(sourcePath, done) {
+      fs.readFile(sourcePath, function(err, content) {
+        if (err) {
+          return done(err);
+        }
+        
+        files.push({
+          name: sourcePath,
+          contents: content.toString()
+        });
+        done();
+      });
+    },function(err) {
+      /* istanbul ignore if */
+      if (err) {
+        return callback(err);
+      } else {
+        callback(null, files);
+      }
+    });
+  };
+
   var loadCompiledGame = function(inPath, callback) {
     fs.readFile(inPath, function(err, json) {
       /* istanbul ignore if */
@@ -293,6 +317,7 @@
     copyTemplate: copyTemplate,
     loadCompiledGame: loadCompiledGame,
     walkDir: walkDir,
+    fetchContent: fetchContent,
 
     Command: Command
   };

--- a/lib/cli/utils.js
+++ b/lib/cli/utils.js
@@ -9,6 +9,7 @@
 
   var path = require('path');
   var fs = require('fs');
+  var dive = require('dive');
   var handlebars = require('handlebars');
   var _ = require('lodash');
 
@@ -58,7 +59,7 @@
     pattern = pattern || /\.dry$/;
 
     var latest = null;
-    compiler.walkDir(diry, {}, function(srcpath, done) {
+    walkDir(diry, {}, function(srcpath, done) {
       // Skip non relevant files.
       if (!pattern.test(srcpath)) {
         return done();
@@ -166,13 +167,13 @@
       if (err) {
         return callback(err);
       }
-      compiler.walkDir(
+      walkDir(
         sourceDir, {directories:true, files:false}, mkDir,
         function(err) {
           if (err) {
             return callback(err);
           }
-          compiler.walkDir(sourceDir, {}, copyFile, function(err) {
+          walkDir(sourceDir, {}, copyFile, function(err) {
             if (err) {
               return callback(err);
             } else {
@@ -186,6 +187,83 @@
     data.year = (new Date()).getFullYear();
     mkDir(sourceDir, doCopy);
   };
+
+  /* An augmented version of dive that allows the processing 'action'
+   * function to be asynchronous. It should accept a parameter
+   * 'finished' which should be called when it has completed its work,
+   * with an error if something happened. Errors are not passed along
+   * to future actions, but actions are stopped and the finish routine
+   * is called. Unlike dive, the finished routine is guaranteed to be
+   * called after all actions have completed, and is passed the error,
+   * if there is one.
+   *
+   * action(src, done); done(err)
+   * finished(err)
+   */
+  var walkDir = function(diry, opts, action, finished) {
+    var hasFinishedDive = false;
+    var donesPending = 0;
+    var error;
+    var completed = false;
+    var complete = function() {
+      if (!completed) {
+        completed = true;
+        if (error !== undefined) {
+          return finished(error);
+        } else {
+          return finished();
+        }
+      }
+    };
+    dive(diry, opts, function(err, srcpath) {
+      if (err) {
+        error = err;
+        /* istanbul ignore else */
+        if (donesPending === 0) {
+          complete();
+        }
+      } else if (!error) {
+        donesPending++;
+        action(srcpath, function(err) {
+          if (err) {
+            error = err;
+          }
+          donesPending--;
+          // This may be untestable, because of the async nature of the walk.
+          /* istanbul ignore next */
+          if (donesPending === 0 && hasFinishedDive) {
+            complete();
+          }
+        });
+      }
+    }, function() {
+      // Only called when no error is passed to the dive action callback.
+      hasFinishedDive = true;
+      // This may be untestable, because of the async nature of the walk.
+      /* istanbul ignore next */
+      if (donesPending === 0) {
+        complete();
+      }
+    });
+  };
+
+  var loadCompiledGame = function(inPath, callback) {
+    fs.readFile(inPath, function(err, json) {
+      /* istanbul ignore if */
+      if (err) {
+        return callback(err);
+      }
+      compiler.convertJSONToGame(json, function(err, game) {
+        /* istanbul ignore if */
+        if (err) {
+          return callback(err);
+        } else {
+          return callback(null, game, json);
+        }
+      });
+    });
+  };
+
 
   // ----------------------------------------------------------------------
 
@@ -213,6 +291,8 @@
     getLatestMTime: getLatestMTime,
     isUpToDate: isUpToDate,
     copyTemplate: copyTemplate,
+    loadCompiledGame: loadCompiledGame,
+    walkDir: walkDir,
 
     Command: Command
   };

--- a/lib/parsers/compiler.js
+++ b/lib/parsers/compiler.js
@@ -10,7 +10,6 @@
   var assert = require('assert');
   var _ = require('lodash');
   var async = require('async');
-  var fs = require('fs');
 
   var infoParser = require('./info');
   var sceneParser = require('./scene');

--- a/lib/parsers/compiler.js
+++ b/lib/parsers/compiler.js
@@ -567,6 +567,7 @@
     var scenes = [prevScene, prevTopScene, jumpScene, backSpecialScene, returnScene];
     var qualities = [];
     var qdisplays = [];
+    
     for(const file of dry_files_contents) {
       const {name:sourcePath, contents} = file;
 
@@ -602,19 +603,19 @@
           }
           qdisplays.push(result);
         });
+        continue;
       } else {
         // Skip this file.
-        callback();
+        continue;
       }
     }
-
     compile(info, scenes, qualities, qdisplays, function(err, game) {
       /* istanbul ignore if */
       if (err) {
         return callback(err);
       }
       callback(null, game);
-    })
+    });
   };
 
   var convertGameToJSON = function(game, indent, callback) {

--- a/lib/parsers/compiler.js
+++ b/lib/parsers/compiler.js
@@ -10,10 +10,7 @@
   var assert = require('assert');
   var _ = require('lodash');
   var async = require('async');
-  var dive = require('dive');
   var fs = require('fs');
-  var path = require('path');
-  var mkdirp = require('mkdirp');
 
   var infoParser = require('./info');
   var sceneParser = require('./scene');
@@ -548,118 +545,10 @@
 
   // ----------------------------------------------------------------------
 
-  /* An augmented version of dive that allows the processing 'action'
-   * function to be asynchronous. It should accept a parameter
-   * 'finished' which should be called when it has completed its work,
-   * with an error if something happened. Errors are not passed along
-   * to future actions, but actions are stopped and the finish routine
-   * is called. Unlike dive, the finished routine is guaranteed to be
-   * called after all actions have completed, and is passed the error,
-   * if there is one.
-   *
-   * action(src, done); done(err)
-   * finished(err)
-   */
-  var walkDir = function(diry, opts, action, finished) {
-    var hasFinishedDive = false;
-    var donesPending = 0;
-    var error;
-    var completed = false;
-    var complete = function() {
-      if (!completed) {
-        completed = true;
-        if (error !== undefined) {
-          return finished(error);
-        } else {
-          return finished();
-        }
-      }
-    };
-    dive(diry, opts, function(err, srcpath) {
-      if (err) {
-        error = err;
-        /* istanbul ignore else */
-        if (donesPending === 0) {
-          complete();
-        }
-      } else if (!error) {
-        donesPending++;
-        action(srcpath, function(err) {
-          if (err) {
-            error = err;
-          }
-          donesPending--;
-          // This may be untestable, because of the async nature of the walk.
-          /* istanbul ignore next */
-          if (donesPending === 0 && hasFinishedDive) {
-            complete();
-          }
-        });
-      }
-    }, function() {
-      // Only called when no error is passed to the dive action callback.
-      hasFinishedDive = true;
-      // This may be untestable, because of the async nature of the walk.
-      /* istanbul ignore next */
-      if (donesPending === 0) {
-        complete();
-      }
-    });
-  };
 
-  // data is a dict of {filename : string containing file data}
-  // TODO: implement this
-  var compileGameFromData = function(filenames, dryData, infoData, callback) {
-    var info = infoParser.parseFromContent(infoData.fileName, infoData.data, function(err, dry) {
-    });
-    // prevScene is a special scene that is always accessible and blank.
-    // TODO: have a better way of displaying special scenes?
-    var prevScene = {id: 'prevScene',
-                     content: {content: '', type: 'paragraph'}};
-    var prevTopScene = {id: 'prevTopScene',
-                     content: {content: '', type: 'paragraph'}};
-    var jumpScene = {id: 'jumpScene',
-                     content: {content: '', type: 'paragraph'}};
-    // returnScene is used with goSub...
-    var returnScene = {id: 'returnScene',
-                       content: {content: '', type: 'paragraph'}};
-    // backSpecialScene should only be used within special scenes,
-    // and is used to go back to the previous non-special scene.
-    var backSpecialScene = {id: 'backSpecialScene',
-                            content: {content: '', type: 'paragraph'}};
-    var scenes = [prevScene, prevTopScene, jumpScene, backSpecialScene, returnScene];
-    var qualities = [];
-    var qdisplays = [];
-    var callbackFn = function(err, result) {
-          /* istanbul ignore if */
-          if (err) {
-            return done(err);
-          }
-          info = result;
-          done();
-    };
-    var dryCallback = function(err, result) {
-          /* istanbul ignore if */
-          if (err) {
-            return done(err);
-          }
-          scenes.push(result);
-          done();
-    };
-    for (var i = 0; i < filenames.length; i++) {
-        var fn = filenames[i];
-        if (/(^|\/)info\.dry$/.test(fn)) {
-            infoParser.parseFromContent(fn, dryData[fn], callbackFn);
-        } else if (/\.scene\.dry$/.test(fn)) {
-            dryParser.parseFromContent(fn, dryData[fn], dryCallback);
-        }
-    }
-  };
-
-  // Compiles a directory of dry data files into a game object.
-  // TODO: refactor this to use a list of file objects rather than html?
-  // just a list of strings...
-  var compileGame = function(sourceDir, callback) {
+  // Compiles a list of dry data files into a game object.
+  // A data file is a dict of the form {name : "filename.type.dry", contents: "string containing file data"}
+  var compileGame = function(dry_files_contents, callback) {
     var info;
     // prevScene is a special scene that is always accessible and blank.
     // TODO: have a better way of displaying special scenes?
@@ -679,101 +568,54 @@
     var scenes = [prevScene, prevTopScene, jumpScene, backSpecialScene, returnScene];
     var qualities = [];
     var qdisplays = [];
-    walkDir(sourceDir, {}, function(sourcePath, done) {
+    for(const file of dry_files_contents) {
+      const {name:sourcePath, contents} = file;
+
       if (/(^|\/)info\.dry$/.test(sourcePath)) {
-        infoParser.parseFromFile(sourcePath, function(err, result) {
+        infoParser.parseFromContent(sourcePath, contents, function(err, result) {
           /* istanbul ignore if */
           if (err) {
-            return done(err);
+            return callback(err);
           }
           info = result;
-          done();
         });
       } else if (/\.scene\.dry$/.test(sourcePath)) {
-        sceneParser.parseFromFile(sourcePath, function(err, result) {
+        sceneParser.parseFromContent(sourcePath, contents, function(err, result) {
           /* istanbul ignore if */
           if (err) {
-            return done(err);
+            return callback(err);
           }
           scenes.push(result);
-          done();
         });
       } else if (/\.quality\.dry$/.test(sourcePath)) {
-        qualityParser.parseFromFile(sourcePath, function(err, result) {
+        qualityParser.parseFromContent(sourcePath, contents, function(err, result) {
           /* istanbul ignore if */
           if (err) {
-            return done(err);
+            return callback(err);
           }
           qualities.push(result);
-          done();
         });
       } else if (/\.qdisplay\.dry$/.test(sourcePath)) {
-        qdisplayParser.parseFromFile(sourcePath, function(err, result) {
+        qdisplayParser.parseFromContent(sourcePath, contents, function(err, result) {
           /* istanbul ignore if */
           if (err) {
-            return done(err);
+            return callback(err);
           }
           qdisplays.push(result);
-          done();
         });
       } else {
         // Skip this file.
-        done();
+        callback();
       }
-    }, function(err) {
-      /* istanbul ignore if */
-      if (err) {
-        return callback(err);
-      } else {
-        compile(info, scenes, qualities, qdisplays, function(err, game) {
-          /* istanbul ignore if */
-          if (err) {
-            return callback(err);
-          }
-          callback(null, game);
-        });
-      }
-    });
-  };
+    }
 
-  var loadCompiledGame = function(inPath, callback) {
-    fs.readFile(inPath, function(err, json) {
+    compile(info, scenes, qualities, qdisplays, function(err, game) {
       /* istanbul ignore if */
       if (err) {
         return callback(err);
       }
-      convertJSONToGame(json, function(err, game) {
-        /* istanbul ignore if */
-        if (err) {
-          return callback(err);
-        } else {
-          return callback(null, game, json);
-        }
-      });
-    });
-  };
-
-  var saveCompiledGame = function(game, outPath, indent, callback) {
-    convertGameToJSON(game, indent, function(err, json) {
-      /* istanbul ignore if */
-      if (err) {
-        return callback(err);
-      }
-      var diry = path.dirname(outPath);
-      mkdirp(diry, function(err) {
-        /* istanbul ignore if */
-        if (err) {
-          return callback(err);
-        }
-        fs.writeFile(outPath, json, function(err) {
-          /* istanbul ignore if */
-          if (err) {
-            return callback(err);
-          }
-          callback(null);
-        });
-      });
-    });
+      callback(null, game);
+    })
   };
 
   var convertGameToJSON = function(game, indent, callback) {
@@ -808,10 +650,7 @@
   module.exports = {
     compile: compile,
     getCandidateAbsoluteIds: getCandidateAbsoluteIds,
-    walkDir: walkDir,
     compileGame: compileGame,
-    loadCompiledGame: loadCompiledGame,
-    saveCompiledGame: saveCompiledGame,
     convertJSONToGame: convertJSONToGame,
     convertGameToJSON: convertGameToJSON
   };

--- a/lib/parsers/dry.js
+++ b/lib/parsers/dry.js
@@ -80,7 +80,8 @@
 
   var filenameRe = /^([\w-]+?(\.[\w-]+?)*?)(\.([\w-]+?))?\.([^.]*)$/;
   var parseFilename = function(filename) {
-    var match = filenameRe.exec(filename);
+    var basename = filename.substr(filename.lastIndexOf('/') + 1);
+    var match = filenameRe.exec(basename);
     if (match) {
       var obj = {
         id: match[1],

--- a/lib/parsers/dry.js
+++ b/lib/parsers/dry.js
@@ -8,7 +8,6 @@
   'use strict';
 
   var _ = require('lodash');
-  var fs = require('fs');
   var assert = require('assert');
 
   var RESERVED_PROPERTIES = {

--- a/lib/parsers/dry.js
+++ b/lib/parsers/dry.js
@@ -8,7 +8,6 @@
   'use strict';
 
   var _ = require('lodash');
-  var path = require('path');
   var fs = require('fs');
   var assert = require('assert');
 
@@ -80,11 +79,9 @@
     }
   };
 
-  var filenameRe = /^([\w-]+?(\.[\w-]+?)*?)(\.([\w-]+?))?$/;
+  var filenameRe = /^([\w-]+?(\.[\w-]+?)*?)(\.([\w-]+?))?\.([^.]*)$/;
   var parseFilename = function(filename) {
-    var ext = path.extname(filename);
-    var base = path.basename(filename, ext);
-    var match = filenameRe.exec(base);
+    var match = filenameRe.exec(filename);
     if (match) {
       var obj = {
         id: match[1],
@@ -423,16 +420,6 @@
     return callback(null, result);
   };
 
-  // Loads and parses the given file.
-  var parseFromFile = function(filename, callback) {
-    fs.readFile(filename, function(err, content) {
-      if (err) {
-        return callback(err);
-      }
-      parseFromContent(filename, content.toString(), callback);
-    });
-  };
-
   // ======================================================================
 
   var removeMetadataFromArray = function(array) {
@@ -496,7 +483,6 @@
 
   module.exports = {
     parseFromContent: parseFromContent,
-    parseFromFile: parseFromFile,
 
     regexes: {
       id: idRe, idString: idReString,

--- a/lib/parsers/make.js
+++ b/lib/parsers/make.js
@@ -33,25 +33,12 @@
     };
   };
 
-  var makeParseFromFile = function(schema) {
-    var ensure = validators.makeEnsureObjectMatchesSchema(schema);
-    return function(filename, callback) {
-      dryParser.parseFromFile(filename, function(err, dry) {
-        if (err) {
-          return callback(err);
-        }
-        ensure(dry, null, callback);
-      });
-    };
-  };
-
   var makeParseFromDry = validators.makeEnsureObjectMatchesSchema;
 
   var makeExports = function(schema) {
     return {
       schema: schema,
       parseFromContent: makeParseFromContent(schema),
-      parseFromFile: makeParseFromFile(schema),
       parseFromDry: makeParseFromDry(schema)
     };
   };
@@ -60,7 +47,6 @@
     extendSchema: extendSchema,
 
     makeParseFromContent: makeParseFromContent,
-    makeParseFromFile: makeParseFromFile,
     makeParseFromDry: makeParseFromDry,
     makeExports: makeExports
   };

--- a/test/test_parsers_compiler.js
+++ b/test/test_parsers_compiler.js
@@ -21,6 +21,7 @@
   };
 
   var compiler = require('../lib/parsers/compiler');
+  var utils = require('../lib/cli/utils');
 
   describe('game compiler', function() {
 
@@ -977,83 +978,43 @@
 
     // ----------------------------------------------------------------------
 
-    describe('compiling files', function() {
-      it('should compile a standard project directory', function(done) {
-        var diry = path.resolve(__dirname, 'files', 'test_game', 'source');
-        compiler.compileGame(diry, function(err, game) {
-          noerr(err);
-          game.title.should.equal('Test Game');
-          game.author.should.equal('Jo Doe');
-          var _;
-          var scenes = 0;
-          for (var sceneName in game.scenes) {
-            if([
-              'backSpecialScene',
-              'jumpScene',
-              'prevScene',
-              'prevTopScene',
-              'returnScene',
-            ].includes(sceneName)){
-              continue;
-            }
-            scenes++;
-          }
-          var qualities = 0;
-          for (_ in game.qualities) {
-            qualities++;
-          }
-          var qdisplays = 0;
-          for (_ in game.qdisplays) {
-            qdisplays++;
-          }
-          scenes.should.equal(6);
-          qualities.should.equal(1);
-          qdisplays.should.equal(1);
-          done();
-        });
-      });
+    // describe('compiling files', function() {
+    //   it('should compile a standard project directory', function(done) {
+    //     var diry = path.resolve(__dirname, 'files', 'test_game', 'source');
+    //     compiler.compileGame(diry, function(err, game) {
+    //       noerr(err);
+    //       game.title.should.equal('Test Game');
+    //       game.author.should.equal('Jo Doe');
+    //       var _;
+    //       var scenes = 0;
+    //       for (var sceneName in game.scenes) {
+    //         if([
+    //           'backSpecialScene',
+    //           'jumpScene',
+    //           'prevScene',
+    //           'prevTopScene',
+    //           'returnScene',
+    //         ].includes(sceneName)){
+    //           continue;
+    //         }
+    //         scenes++;
+    //       }
+    //       var qualities = 0;
+    //       for (_ in game.qualities) {
+    //         qualities++;
+    //       }
+    //       var qdisplays = 0;
+    //       for (_ in game.qdisplays) {
+    //         qdisplays++;
+    //       }
+    //       scenes.should.equal(6);
+    //       qualities.should.equal(1);
+    //       qdisplays.should.equal(1);
+    //       done();
+    //     });
+    //   });
 
-      it('should load and save a game', function(done) {
-        var info = {
-          title: 'My Game',
-          author: 'Jo Doe'
-        };
-        var fn = function(state, Q) { Q.foo += 1; };
-        fn.source = 'Q.foo += 1;';
-        var scenes = [
-          {
-            id: 'root',
-            title:'The Root',
-            content: 'Root content',
-            onArrival: [fn]
-          },
-          {id: 'foo', title:'The Foo', content:'Foo content'}
-        ];
-        var qualities = [
-        ];
-        var qdisps = [];
-        compiler.compile(info, scenes, qualities, qdisps, function(err, game) {
-          noerr(err);
-          var filename = '/tmp/test-dendry.game';
-          compiler.saveCompiledGame(game, filename, 0, function(err) {
-            noerr(err);
-            compiler.loadCompiledGame(filename, function(err, loaded) {
-              noerr(err);
-              // Function comparisons don't work without should.eql(),
-              // so compare them and delete them.
-              game.scenes.root.onArrival[0].source.should.equal(
-                loaded.scenes.root.onArrival[0].source
-              );
-              delete game.scenes.root.onArrival;
-              delete loaded.scenes.root.onArrival;
-              game.should.eql(loaded);
-              done();
-            });
-          });
-        });
-      });
-
-    }); // end describe loading/saving
+    // }); // end describe loading/saving
 
     // ----------------------------------------------------------------------
 
@@ -1068,7 +1029,7 @@
             pathDone();
           }
         };
-        compiler.walkDir(diry, {}, action, function(err) {
+        utils.walkDir(diry, {}, action, function(err) {
           (!!err).should.be.true;
           err.toString().should.equal('Error: Too many files processed.');
           done();
@@ -1080,7 +1041,7 @@
         var action = function(_, pathDone) {
           pathDone();
         };
-        compiler.walkDir(diry, {}, action, function(err) {
+        utils.walkDir(diry, {}, action, function(err) {
           (!!err).should.be.true;
           err.toString().should.match(/Error: ENOENT/);
           done();

--- a/test/test_parsers_compiler.js
+++ b/test/test_parsers_compiler.js
@@ -978,43 +978,45 @@
 
     // ----------------------------------------------------------------------
 
-    // describe('compiling files', function() {
-    //   it('should compile a standard project directory', function(done) {
-    //     var diry = path.resolve(__dirname, 'files', 'test_game', 'source');
-    //     compiler.compileGame(diry, function(err, game) {
-    //       noerr(err);
-    //       game.title.should.equal('Test Game');
-    //       game.author.should.equal('Jo Doe');
-    //       var _;
-    //       var scenes = 0;
-    //       for (var sceneName in game.scenes) {
-    //         if([
-    //           'backSpecialScene',
-    //           'jumpScene',
-    //           'prevScene',
-    //           'prevTopScene',
-    //           'returnScene',
-    //         ].includes(sceneName)){
-    //           continue;
-    //         }
-    //         scenes++;
-    //       }
-    //       var qualities = 0;
-    //       for (_ in game.qualities) {
-    //         qualities++;
-    //       }
-    //       var qdisplays = 0;
-    //       for (_ in game.qdisplays) {
-    //         qdisplays++;
-    //       }
-    //       scenes.should.equal(6);
-    //       qualities.should.equal(1);
-    //       qdisplays.should.equal(1);
-    //       done();
-    //     });
-    //   });
+    describe('compiling files', function() {
+      it('should compile a standard project directory', function(done) {
+        var diry = path.resolve(__dirname, 'files', 'test_game', 'source');
+        utils.fetchContent(diry, function(err, files) {
+          compiler.compileGame(files, function(err, game) {
+            noerr(err);
+            game.title.should.equal('Test Game');
+            game.author.should.equal('Jo Doe');
+            var _;
+            var scenes = 0;
+            for (var sceneName in game.scenes) {
+              if([
+                'backSpecialScene',
+                'jumpScene',
+                'prevScene',
+                'prevTopScene',
+                'returnScene',
+              ].includes(sceneName)){
+                continue;
+              }
+              scenes++;
+            }
+            var qualities = 0;
+            for (_ in game.qualities) {
+              qualities++;
+            }
+            var qdisplays = 0;
+            for (_ in game.qdisplays) {
+              qdisplays++;
+            }
+            scenes.should.equal(6);
+            qualities.should.equal(1);
+            qdisplays.should.equal(1);
+            done();
+          });
+        });
+      });
 
-    // }); // end describe loading/saving
+    }); // end describe loading/saving
 
     // ----------------------------------------------------------------------
 

--- a/test/test_parsers_dry.js
+++ b/test/test_parsers_dry.js
@@ -631,32 +631,6 @@
 
     });
 
-    // ----------------------------------------------------------------------
-
-    describe('filesystem', function() {
-      it('should load and parse file', function(done) {
-        var fn = path.join(__dirname, 'files', 'test_dry_parser.test.dry');
-        parse.parseFromFile(fn, function(err, result) {
-          noerr(err);
-          result.id.should.equal('test_dry_parser');
-          result.type.should.equal('test');
-          result.sections.length.should.equal(4);
-          result.sections[0].id.should.equal('test_dry_parser.new-id');
-          result.sections[0].options.length.should.equal(4);
-          done();
-        });
-      });
-
-      it('should fail if the file is not there', function(done) {
-        var fn = path.join(__dirname, 'files', 'not-a-file.type.dry');
-        parse.parseFromFile(fn, function(err, result) {
-          (!!err).should.be.true;
-          (result === undefined).should.be.true;
-          done();
-        });
-      });
-
-    });
 
     // ----------------------------------------------------------------------
 

--- a/test/test_parsers_info.js
+++ b/test/test_parsers_info.js
@@ -8,12 +8,24 @@
   'use strict';
 
   var path = require('path');
+  var fs = require('fs');
   var should = require('should');
   // Disable errors from using the should library.
   /*jshint -W030 */
 
   var parse = require('../lib/parsers/info');
   var dryParser = require('../lib/parsers/dry');
+
+
+  // Loads and parses the given file.
+  var parseFromFile = function(parseFromContent, filename, callback) {
+    fs.readFile(filename, function(err, content) {
+      if (err) {
+        return callback(err);
+      }
+      parseFromContent(filename, content.toString(), callback);
+    });
+  };
 
   describe('info parser', function() {
 
@@ -99,7 +111,7 @@
 
     it('should load and parse info file', function(done) {
       var fn = path.join(__dirname, 'files', 'test_info_parser.info.dry');
-      parse.parseFromFile(fn, function(err, result) {
+      parseFromFile(parse.parseFromContent, fn, function(err, result) {
         (!!err).should.be.false;
         dryParser.removeMetadataFromObject(result);
         result.should.eql({
@@ -114,7 +126,7 @@
 
     it('should pass on dry file errors', function(done) {
       var fn = path.join(__dirname, 'files', 'unknown.scene.dry');
-      parse.parseFromFile(fn, function(err, result) {
+      parseFromFile(parse.parseFromContent, fn, function(err, result) {
         (!!err).should.be.true;
         (result === undefined).should.be.true;
         done();

--- a/test/test_parsers_quality.js
+++ b/test/test_parsers_quality.js
@@ -8,6 +8,7 @@
   'use strict';
 
   var path = require('path');
+  var fs = require('fs');
   var should = require('should');
   // Disable errors from using the should library.
   /*jshint -W030 */
@@ -21,6 +22,16 @@
 
   var parse = require('../lib/parsers/quality');
   var dryParser = require('../lib/parsers/dry');
+
+  // Loads and parses the given file.
+  var parseFromFile = function(parseFromContent, filename, callback) {
+    fs.readFile(filename, function(err, content) {
+      if (err) {
+        return callback(err);
+      }
+      parseFromContent(filename, content.toString(), callback);
+    });
+  };
 
   describe('quality parser', function() {
 
@@ -121,7 +132,7 @@
 
     it('should load and parse quality file', function(done) {
       var fn = path.join(__dirname, 'files', 'test_quality_parser.quality.dry');
-      parse.parseFromFile(fn, function(err, result) {
+      parseFromFile(parse.parseFromContent, fn, function(err, result) {
         noerr(err);
         dryParser.removeMetadataFromObject(result);
         result.should.eql({
@@ -140,7 +151,7 @@
 
     it('should pass on dry file errors', function(done) {
       var fn = path.join(__dirname, 'files', 'unknown.scene.dry');
-      parse.parseFromFile(fn, function(err, result) {
+      parseFromFile(parse.parseFromContent, fn, function(err, result) {
         (!!err).should.be.true;
         (result === undefined).should.be.true;
         done();

--- a/test/test_parsers_scene.js
+++ b/test/test_parsers_scene.js
@@ -8,6 +8,7 @@
   'use strict';
 
   var path = require('path');
+  var fs = require('fs');
   var should = require('should');
   // Disable errors from using the should library.
   /*jshint -W030 */
@@ -21,6 +22,16 @@
 
   var parse = require('../lib/parsers/scene');
   var dryParser = require('../lib/parsers/dry');
+
+  // Loads and parses the given file.
+  var parseFromFile = function(parseFromContent, filename, callback) {
+    fs.readFile(filename, function(err, content) {
+      if (err) {
+        return callback(err);
+      }
+      parseFromContent(filename, content.toString(), callback);
+    });
+  };
 
   describe('scene parser', function() {
 
@@ -215,7 +226,7 @@
 
     it('should load and parse scene file', function(done) {
       var fn = path.join(__dirname, 'files', 'test_scene_parser.scene.dry');
-      parse.parseFromFile(fn, function(err, result) {
+      parseFromFile(parse.parseFromContent, fn, function(err, result) {
         noerr(err);
         dryParser.removeMetadataFromObject(result);
         result.should.eql({
@@ -245,7 +256,7 @@
 
     it('should pass on dry file errors', function(done) {
       var fn = path.join(__dirname, 'files', 'unknown.scene.dry');
-      parse.parseFromFile(fn, function(err, result) {
+      parseFromFile(parse.parseFromContent, fn, function(err, result) {
         (!!err).should.be.true;
         (result === undefined).should.be.true;
         done();


### PR DESCRIPTION
## Checklist

- [x] The new code additions passed the tests (`npm test`). 🥳 


## Description
- Move all function requiring node-only modules (fs, path, dive) to cli/utils and tests
- compileGame now accepts an array of contents

## TODO
- some tests do not work yet
- update linter to esnext to be able to use const and for..of